### PR TITLE
Fix issues with Heuft OPC UA server

### DIFF
--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -1379,6 +1379,9 @@ impl SessionService for Session {
                 // and the server and use that to compensate for the difference in time.
                 if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
                     let offset = response.response_header.timestamp - DateTime::now();
+
+                    info!("handling CreateSessionResponse, received timestamp {}, now is {}, offset is {}", response.response_header.timestamp, DateTime::now(), offset);
+
                     // Update the client offset by adding the new offset.
                     session_state.set_client_offset(offset);
                 }

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -1383,8 +1383,6 @@ impl SessionService for Session {
                 {
                     let offset = response.response_header.timestamp - DateTime::now();
 
-                    info!("handling CreateSessionResponse, received timestamp {}, now is {}, offset is {}", response.response_header.timestamp, DateTime::now(), offset);
-
                     // Update the client offset by adding the new offset.
                     session_state.set_client_offset(offset);
                 }

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -1377,7 +1377,10 @@ impl SessionService for Session {
                 }
                 // When ignoring clock skew, we calculate the time offset between the client
                 // and the server and use that to compensate for the difference in time.
-                if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
+                if self.ignore_clock_skew
+                    && !response.response_header.timestamp.is_null()
+                    && response.response_header.timestamp > DateTime::ymd(2000, 1, 1)
+                {
                     let offset = response.response_header.timestamp - DateTime::now();
 
                     info!("handling CreateSessionResponse, received timestamp {}, now is {}, offset is {}", response.response_header.timestamp, DateTime::now(), offset);

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -195,7 +195,7 @@ impl SessionState {
 
     pub fn set_client_offset(&mut self, offset: Duration) {
         self.client_offset = self.client_offset + offset;
-        info!("Client offset set to {}", self.client_offset);
+        debug!("Client offset set to {}", self.client_offset);
     }
 
     pub fn set_session_id(&mut self, session_id: NodeId) {

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -195,7 +195,7 @@ impl SessionState {
 
     pub fn set_client_offset(&mut self, offset: Duration) {
         self.client_offset = self.client_offset + offset;
-        debug!("Client offset set to {}", self.client_offset);
+        info!("Client offset set to {}", self.client_offset);
     }
 
     pub fn set_session_id(&mut self, session_id: NodeId) {
@@ -464,6 +464,9 @@ impl SessionState {
             // received from the server.
             if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
                 let offset = response.response_header.timestamp - DateTime::now();
+
+                info!("handling OpenSecureChannelResponse, received timestamp {}, now is {}, offset is {}", response.response_header.timestamp, DateTime::now(), offset);
+
                 // Make sure to apply the offset to the security token in the current response.
                 security_token.created_at = security_token.created_at - offset;
                 // Update the client offset by adding the new offset. When the secure channel is

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -462,12 +462,13 @@ impl SessionState {
             // server and use that offset to compensate for the difference in time when setting
             // the timestamps in the request headers and when decoding timestamps in messages
             // received from the server.
-            if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
+            if self.ignore_clock_skew
+                && !response.response_header.timestamp.is_null()
+                && response.response_header.timestamp > DateTime::ymd(2000, 1, 1)
+            {
                 let offset = response.response_header.timestamp - DateTime::now();
 
-                info!("handling OpenSecureChannelResponse, received timestamp {}, now is {}, offset is {}", response.response_header.timestamp, DateTime::now(), offset);
-
-                // Make sure to apply the offset to the security token in the current response.
+               // Make sure to apply the offset to the security token in the current response.
                 security_token.created_at = security_token.created_at - offset;
                 // Update the client offset by adding the new offset. When the secure channel is
                 // renewed its already using the client offset calculated when issuing the secure

--- a/lib/src/core/tests/comms.rs
+++ b/lib/src/core/tests/comms.rs
@@ -133,4 +133,7 @@ pub fn secure_channel_nonce_none() {
     assert!(sc
         .set_remote_nonce_from_byte_string(&ByteString::from(b""))
         .is_ok());
+    assert!(sc
+        .set_remote_nonce_from_byte_string(&ByteString::null())
+        .is_ok());
 }

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -71,20 +71,9 @@ impl BinaryEncoder<DateTime> for DateTime {
         let ticks = read_i64(stream)?;
         let date_time = DateTime::from(ticks);
 
-        let now = chrono::Utc::now();
-        if (date_time.date_time - now).num_seconds() > 3600 {
-            warn!("unexpectedly deserializing {ticks} to {date_time}, but it is {now} now");
-        }
-        warn!("client offset = {}", decoding_options.client_offset);
-        
-        let corrected_dt = date_time - decoding_options.client_offset;
-        if (corrected_dt.date_time - now).num_seconds() > 3600 {
-            warn!("date time client offset is changing {date_time} to {corrected_dt}, but it is {now} now");
-        }
-
         // Client offset is a value that can be overridden to account for time discrepancies between client & server -
         // note perhaps it is not a good idea to do it right here but it is the lowest point to intercept DateTime values.
-        Ok(corrected_dt)
+        Ok(date_time - decoding_options.client_offset)
     }
 }
 

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -50,6 +50,12 @@ impl<'de> Deserialize<'de> for DateTime {
         let v = String::deserialize(deserializer)?;
         let dt = DateTime::parse_from_rfc3339(&v)
             .map_err(|_| D::Error::custom("Cannot parse date time"))?;
+
+        let now = chrono::Utc::now();
+        if (dt.date_time - now).num_seconds() > 3600 {
+            warn!("unexpectedly deserializing {v} to {dt}, but it is {now} now");
+        }
+
         Ok(dt)
     }
 }

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -75,6 +75,7 @@ impl BinaryEncoder<DateTime> for DateTime {
         if (date_time.date_time - now).num_seconds() > 3600 {
             warn!("unexpectedly deserializing {ticks} to {date_time}, but it is {now} now");
         }
+        warn!("client offset = {}", decoding_options.client_offset);
         
         let corrected_dt = date_time - decoding_options.client_offset;
         if (corrected_dt.date_time - now).num_seconds() > 3600 {

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -48,6 +48,7 @@ impl<'de> Deserialize<'de> for DateTime {
         D: Deserializer<'de>,
     {
         let v = String::deserialize(deserializer)?;
+        println!("{v}");
         let dt = DateTime::parse_from_rfc3339(&v)
             .map_err(|_| D::Error::custom("Cannot parse date time"))?;
 

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -48,10 +48,8 @@ impl<'de> Deserialize<'de> for DateTime {
         D: Deserializer<'de>,
     {
         let v = String::deserialize(deserializer)?;
-
         let dt = DateTime::parse_from_rfc3339(&v)
             .map_err(|_| D::Error::custom("Cannot parse date time"))?;
-
         Ok(dt)
     }
 }
@@ -70,7 +68,6 @@ impl BinaryEncoder<DateTime> for DateTime {
     fn decode<S: Read>(stream: &mut S, decoding_options: &DecodingOptions) -> EncodingResult<Self> {
         let ticks = read_i64(stream)?;
         let date_time = DateTime::from(ticks);
-
         // Client offset is a value that can be overridden to account for time discrepancies between client & server -
         // note perhaps it is not a good idea to do it right here but it is the lowest point to intercept DateTime values.
         Ok(date_time - decoding_options.client_offset)


### PR DESCRIPTION
Heuft server will respond with "BadNonceInvalid" when getting a NULL nonce during the "CreateSession" command. Furthermore it sends wonky almost null server timestamps sometimes, messing up clock skew math, so, disregarding any timestamp before year 2000